### PR TITLE
Fix: Configurar URLs da API para desenvolvimento local

### DIFF
--- a/.env
+++ b/.env
@@ -1,10 +1,10 @@
 # URL da API do back-end
-VITE_API_URL=http://localhost:5000/api
+VITE_API_URL=http://200.98.64.133:5000/api
 
 # Configurações de desenvolvimento
 VITE_NODE_ENV=development
 
 # URLs das APIs externas (para referência)
-VITE_GOOGLE_PLAY_API=http://localhost:5000/api/scraping/google-play
-VITE_APPLE_STORE_API=http://localhost:5000/api/scraping/apple-store
+VITE_GOOGLE_PLAY_API=http://200.98.64.133:5000/api/scraping/google-play
+VITE_APPLE_STORE_API=http://200.98.64.133:5000/api/scraping/apple-store
 

--- a/.env
+++ b/.env
@@ -1,10 +1,10 @@
 # URL da API do back-end
-VITE_API_URL=http://200.98.64.133/api
+VITE_API_URL=http://localhost:5000/api
 
 # Configurações de desenvolvimento
 VITE_NODE_ENV=development
 
 # URLs das APIs externas (para referência)
-VITE_GOOGLE_PLAY_API=http://200.98.64.133:5000/api/scraping/google-play
-VITE_APPLE_STORE_API=http://200.98.64.133:5000/api/scraping/apple-store
+VITE_GOOGLE_PLAY_API=http://localhost:5000/api/scraping/google-play
+VITE_APPLE_STORE_API=http://localhost:5000/api/scraping/apple-store
 


### PR DESCRIPTION
- Alterar VITE_API_URL para http://localhost:5000/api
- Alterar URLs das APIs externas para localhost
- Permitir desenvolvimento local sem dependência de servidor remoto